### PR TITLE
update link to use lists.perl.org

### DIFF
--- a/templates/main_index.tt
+++ b/templates/main_index.tt
@@ -186,7 +186,7 @@
                 <a href="mailto:community@opusvl.com"><img class="opus-logo" src="/public/img/opusvl_logo.svg" alt="OpusVL Logo"></a>
               </li>
               <li>Docs mantained by
-                <a href="//lists.cpan.org/showlist.cgi?name=perl5-porters" rel="noopener">Perl 5 Porters</a>
+                <a href="https://lists.perl.org/list/perl5-porters.html" rel="noopener">Perl 5 Porters</a>
               </li>
               <li>Development supported by
                 <a href="//opusvl.com" rel="noopener">OpusVL</a>


### PR DESCRIPTION
lists.cpan.org is long gone.